### PR TITLE
7 add named capture group namespaces

### DIFF
--- a/src/Appenders.test.ts
+++ b/src/Appenders.test.ts
@@ -5,15 +5,48 @@ import { capture, group, match, namedCapture } from "./index"
 describe("Appenders", () => {
   describe("group", () => {
     it("works", () => {
-      const test = group(match.anyChar.and.wordChar)
-      expect(test.getState()).toMatchObject(createState({ curExp: "(?:.\\w)" }))
+      const test = group(
+        match.anyChar.as
+          .namedCapture("test")
+          .and.group(
+            match.anyChar.and.wordChar.groupedAs.namedCapture("test").and.backreferenceTo("test"),
+            { namespace: "prefix-", asPrefix: true }
+          ),
+        { namespace: "-suffix", asPrefix: false }
+      )
+
+      expect(test.getState()).toMatchObject(
+        createState({
+          curExp: "(?:(?<test-suffix>.)(?:.(?<prefix-test-suffix>\\w)\\k<prefix-test-suffix>))",
+          prvExp: "",
+          names: ["test-suffix", "prefix-test-suffix"],
+          groups: ["(?<test-suffix>.)", "(?<prefix-test-suffix>\\w)"],
+        })
+      )
     })
   })
 
   describe("capture", () => {
     it("works", () => {
-      const test = capture(match.anyChar.and.wordChar)
-      expect(test.getState()).toMatchObject(createState({ curExp: "(.\\w)", groups: ["(.\\w)"] }))
+      const test = capture(
+        capture(match.anyChar.and.wordChar.as.namedCapture("test"), {
+          namespace: "prefix-",
+          asPrefix: true,
+        }),
+        { namespace: "-suffix", asPrefix: false }
+      )
+      expect(test.getState()).toMatchObject(
+        createState({
+          curExp: "((.(?<prefix-test-suffix>\\w)))",
+          prvExp: "",
+          names: ["prefix-test-suffix"],
+          groups: [
+            "((.(?<prefix-test-suffix>\\w)))",
+            "(.(?<prefix-test-suffix>\\w))",
+            "(?<prefix-test-suffix>\\w)",
+          ],
+        })
+      )
     })
   })
 
@@ -21,14 +54,24 @@ describe("Appenders", () => {
     it("works with high complexity", () => {
       const test = namedCapture(
         "test",
-        match.anyChar.and.wordChar.thatRepeats.greedily.oneOrMore.groupedAs.namedCapture("asdf")
-      ).and.anyChar.as.capture.and.group(match.anyChar.and.wordChar)
+        namedCapture(
+          "test",
+          match.anyChar.and.wordChar.thatRepeats.greedily.oneOrMore.groupedAs.namedCapture("bro"),
+          { namespace: "prefix-", asPrefix: true }
+        ).and.anyChar.as.capture.and.group(match.anyChar.and.wordChar),
+        { namespace: "-suffix", asPrefix: false }
+      )
       expect(test.getState()).toMatchObject(
         createState({
-          curExp: "(?:.\\w)",
-          prvExp: "(?<test>.(?<asdf>\\w+))(.)",
-          names: ["test", "asdf"],
-          groups: ["(?<test>.(?<asdf>\\w+))", "(?<asdf>\\w+)", "(.)"],
+          curExp: "(?<test>(?<test-suffix>.(?<prefix-bro-suffix>\\w+))(.)(?:.\\w))",
+          prvExp: "",
+          names: ["test", "test-suffix", "prefix-bro-suffix"],
+          groups: [
+            "(?<test>(?<test-suffix>.(?<prefix-bro-suffix>\\w+))(.)(?:.\\w))",
+            "(?<test-suffix>.(?<prefix-bro-suffix>\\w+))",
+            "(?<prefix-bro-suffix>\\w+)",
+            "(.)",
+          ],
         })
       )
     })
@@ -36,8 +79,46 @@ describe("Appenders", () => {
 
   describe("append", () => {
     it("works", () => {
-      const test = match.anyChar.and.wordChar.and.append(match.anyChar.and.wordChar)
-      expect(test.getState()).toMatchObject(createState({ curExp: "\\w", prvExp: ".\\w." }))
+      const test = match.anyChar.as
+        .namedCapture("test")
+        .and.append(match.anyChar)
+        .and.append(match.anyChar.as.namedCapture("test"), {
+          namespace: "prefix-",
+          asPrefix: true,
+        })
+        .and.append(match.anyChar.as.namedCapture("test"), {
+          namespace: "-suffix",
+          asPrefix: false,
+        })
+      expect(test.getState()).toMatchObject(
+        createState({
+          curExp: "(?<test-suffix>.)",
+          prvExp: "(?<test>.).(?<prefix-test>.)",
+          names: ["test", "prefix-test", "test-suffix"],
+          groups: ["(?<test>.)", "(?<prefix-test>.)", "(?<test-suffix>.)"],
+        })
+      )
+    })
+  })
+
+  describe("backreferenceTo", () => {
+    it("works with a numbered reference", () => {
+      const test = capture(match.anyChar).and.backreferenceTo(1)
+      expect(test.getState()).toMatchObject(
+        createState({ curExp: "\\1", prvExp: "(.)", groups: ["(.)"] })
+      )
+    })
+
+    it("works with a named reference", () => {
+      const test = namedCapture("test", match.anyChar).and.backreferenceTo("test")
+      expect(test.getState()).toMatchObject(
+        createState({
+          curExp: "\\k<test>",
+          prvExp: "(?<test>.)",
+          names: ["test"],
+          groups: ["(?<test>.)"],
+        })
+      )
     })
   })
 })

--- a/src/Appenders.ts
+++ b/src/Appenders.ts
@@ -1,56 +1,128 @@
-import type { Assert, Contains, Join, Letter, NoOverlap, OfLength, StartsWith, State } from "@types"
+import {
+  AppenderOpts,
+  Assert,
+  Contains,
+  GroupReferences,
+  Join,
+  Letter,
+  MapWrap,
+  NoOverlap,
+  OfLength,
+  StartsWith,
+  State,
+  MapWrapSearch,
+  WrapSearch,
+} from "@types"
 import { createState, DEFAULT_MESSAGE } from "@utils"
 import { BaseRegExp } from "./BaseRegExp"
 import { TypedRegExp } from "./TypedRegExp"
 
 export class Appenders<CurState extends State> extends BaseRegExp<CurState> {
+  private namespaceState = <
+    TState extends State,
+    Prefix extends string = "",
+    Suffix extends string = "",
+    TCurExp = WrapSearch<TState["curExp"], Prefix, Suffix, "?<", ">">,
+    TPrvExp = WrapSearch<TState["prvExp"], Prefix, Suffix, "?<", ">">,
+    TGroups = MapWrapSearch<TState["groups"], Prefix, Suffix, "?<", ">">,
+    FinalNewNames = MapWrap<TState["names"], Prefix, Suffix>,
+    FinalCurExp = WrapSearch<TCurExp, Prefix, Suffix, "\\k<", ">">,
+    FinalPrvExp = WrapSearch<TPrvExp, Prefix, Suffix, "\\k<", ">">,
+    FinalGroups = MapWrapSearch<TGroups, Prefix, Suffix, "\\k<", ">">
+  >(
+    state: TState,
+    prefix: Prefix,
+    suffix: Suffix
+  ) => {
+    const newCurExp = `${state.curExp}`
+      .replace(/\?<(.*?)>/g, `?<${prefix}$1${suffix}>`)
+      .replace(/\\k<(.*?)>/g, `\\k<${prefix}$1${suffix}>`)
+    const newPrvExp = `${state.prvExp}`
+      .replace(/\?<(.*?)>/g, `?<${prefix}$1${suffix}>`)
+      .replace(/\\k<(.*?)>/g, `\\k<${prefix}$1${suffix}>`)
+    const newNames = state.names.map((name) => `${prefix}${name}${suffix}`)
+    const newGroups = state.groups.map((group) =>
+      group
+        .replace(/\?<(.*?)>/g, `?<${prefix}$1${suffix}>`)
+        .replace(/\\k<(.*?)>/g, `\\k<${prefix}$1${suffix}>`)
+    )
+
+    return {
+      msg: state.msg as TState["msg"],
+      curExp: newCurExp as FinalCurExp,
+      prvExp: newPrvExp as FinalPrvExp,
+      names: newNames as FinalNewNames,
+      groups: newGroups as FinalGroups,
+    }
+  }
+
   group = <
     TState extends State,
+    Namespace extends string = "",
+    AsPrefix extends boolean = true,
+    Prefix extends string = AsPrefix extends true ? Namespace : "",
+    Suffix extends string = AsPrefix extends true ? "" : Namespace,
     IsValidType = Contains<TState["msg"], typeof DEFAULT_MESSAGE>,
     InvalidTypeErr = `❌ Only finalized expressions ready for RegExp conversion can be appended`,
-    HasNoOverlap = NoOverlap<TState["names"], CurState["names"]>,
+    HasNoOverlap = NoOverlap<MapWrap<TState["names"], Prefix, Suffix>, CurState["names"]>,
     OverlapErr = `❌ The name '${Join<HasNoOverlap>}' has already been used. Make sure none of the following names are duplicated: ${Join<
       CurState["names"]
     >}`
   >(
     instance: Assert<IsValidType, InvalidTypeErr> &
       BaseRegExp<TState> &
-      Assert<HasNoOverlap, OverlapErr>
+      Assert<HasNoOverlap, OverlapErr>,
+    options?: AppenderOpts<Namespace, AsPrefix>
   ) => {
+    const opts = options ?? { namespace: "", asPrefix: true }
+    const prefix = (opts.asPrefix ? opts.namespace : "") as Prefix
+    const suffix = (opts.asPrefix ? "" : opts.namespace) as Suffix
     const newState = instance.getState()
+    const namespacedState = this.namespaceState(newState, prefix, suffix)
+
     return new TypedRegExp(
       this.merge({
-        msg: newState.msg,
-        curExp: `(?:${newState.prvExp}${newState.curExp})`,
+        msg: namespacedState.msg,
+        curExp: `(?:${namespacedState.prvExp}${namespacedState.curExp})`,
         prvExp: `${this.state.prvExp}${this.state.curExp}`,
-        names: [...this.state.names, ...newState.names],
-        groups: [...this.state.groups, ...newState.groups],
+        names: [...this.state.names, ...namespacedState.names],
+        groups: [...this.state.groups, ...namespacedState.groups],
       })
     )
   }
 
   capture = <
     TState extends State,
+    Namespace extends string = "",
+    AsPrefix extends boolean = true,
+    Prefix extends string = AsPrefix extends true ? Namespace : "",
+    Suffix extends string = AsPrefix extends true ? "" : Namespace,
     IsValidType = Contains<TState["msg"], typeof DEFAULT_MESSAGE>,
     InvalidTypeErr = `❌ Only finalized expressions ready for RegExp conversion can be appended`,
-    HasNoOverlap = NoOverlap<TState["names"], CurState["names"]>,
+    HasNoOverlap = NoOverlap<MapWrap<TState["names"], Prefix, Suffix>, CurState["names"]>,
     OverlapErr = `❌ The name '${Join<HasNoOverlap>}' has already been used. Make sure none of the following names are duplicated: ${Join<
       CurState["names"]
     >}`
   >(
     instance: Assert<IsValidType, InvalidTypeErr> &
       BaseRegExp<TState> &
-      Assert<HasNoOverlap, OverlapErr>
+      Assert<HasNoOverlap, OverlapErr>,
+    options?: AppenderOpts<Namespace, AsPrefix>
   ) => {
+    const opts = options ?? { namespace: "", asPrefix: true }
+    const prefix = (opts.asPrefix ? opts.namespace : "") as Prefix
+    const suffix = (opts.asPrefix ? "" : opts.namespace) as Suffix
     const newState = instance.getState()
-    const group = `(${newState.prvExp}${newState.curExp})` as const
+    const namespacedState = this.namespaceState(newState, prefix, suffix)
+
+    const group = `(${namespacedState.prvExp}${namespacedState.curExp})` as const
     return new TypedRegExp(
       this.merge({
-        msg: newState.msg,
+        msg: namespacedState.msg,
         curExp: group,
         prvExp: `${this.state.prvExp}${this.state.curExp}`,
-        names: [...this.state.names, ...newState.names],
-        groups: [...this.state.groups, group, ...newState.groups],
+        names: [...this.state.names, ...namespacedState.names],
+        groups: [...this.state.groups, group, ...namespacedState.groups],
       })
     )
   }
@@ -58,6 +130,10 @@ export class Appenders<CurState extends State> extends BaseRegExp<CurState> {
   namedCapture = <
     TState extends State,
     Name extends string,
+    Namespace extends string = "",
+    AsPrefix extends boolean = true,
+    Prefix extends string = AsPrefix extends true ? Namespace : "",
+    Suffix extends string = AsPrefix extends true ? "" : Namespace,
     NameIsNotEmpty = OfLength<Name, number>,
     NameEmptyErr = `❌ The Name '${Name}' must be a non-empty string`,
     NameStartsWithLetter = StartsWith<Name, Letter>,
@@ -68,7 +144,10 @@ export class Appenders<CurState extends State> extends BaseRegExp<CurState> {
     >}`,
     IsValidType = Contains<TState["msg"], typeof DEFAULT_MESSAGE>,
     InvalidTypeErr = `❌ Only finalized expressions ready for RegExp conversion can be appended`,
-    InstanceHasNoOverlap = NoOverlap<TState["names"], [...CurState["names"], Name]>,
+    InstanceHasNoOverlap = NoOverlap<
+      MapWrap<TState["names"], Prefix, Suffix>,
+      [...CurState["names"], Name]
+    >,
     InstanceOverlapErr = `❌ The name '${Join<InstanceHasNoOverlap>}' has already been used. Make sure none of the following names are duplicated: ${Join<
       [...CurState["names"], Name]
     >}`
@@ -79,44 +158,76 @@ export class Appenders<CurState extends State> extends BaseRegExp<CurState> {
       Assert<NameHasNoOverlap, NameOverlapErr>,
     instance: Assert<IsValidType, InvalidTypeErr> &
       BaseRegExp<TState> &
-      Assert<InstanceHasNoOverlap, InstanceOverlapErr>
+      Assert<InstanceHasNoOverlap, InstanceOverlapErr>,
+    options?: AppenderOpts<Namespace, AsPrefix>
   ) => {
+    const opts = options ?? { namespace: "", asPrefix: true }
+    const prefix = (opts.asPrefix ? opts.namespace : "") as Prefix
+    const suffix = (opts.asPrefix ? "" : opts.namespace) as Suffix
     const newState = instance.getState()
-    const group = `(?<${name}>${newState.prvExp}${newState.curExp})` as const
+    const namespacedState = this.namespaceState(newState, prefix, suffix)
+
+    const group = `(?<${name}>${namespacedState.prvExp}${namespacedState.curExp})` as const
     return new TypedRegExp(
       this.merge({
-        msg: newState.msg,
+        msg: namespacedState.msg,
         curExp: group,
         prvExp: `${this.state.prvExp}${this.state.curExp}`,
-        names: [...this.state.names, name, ...newState.names],
-        groups: [...this.state.groups, group, ...newState.groups],
+        names: [...this.state.names, name, ...namespacedState.names],
+        groups: [...this.state.groups, group, ...namespacedState.groups],
       })
     )
   }
 
   append = <
     TState extends State,
+    Namespace extends string = "",
+    AsPrefix extends boolean = true,
+    Prefix extends string = AsPrefix extends true ? Namespace : "",
+    Suffix extends string = AsPrefix extends true ? "" : Namespace,
     IsValidType = Contains<TState["msg"], typeof DEFAULT_MESSAGE>,
     InvalidTypeErr = `❌ Only finalized expressions ready for RegExp conversion can be appended`,
-    HasNoOverlap = NoOverlap<TState["names"], CurState["names"]>,
+    HasNoOverlap = NoOverlap<MapWrap<TState["names"], Prefix, Suffix>, CurState["names"]>,
     OverlapErr = `❌ The name '${Join<HasNoOverlap>}' has already been used. Make sure none of the following names are duplicated: ${Join<
       CurState["names"]
     >}`
   >(
     instance: Assert<IsValidType, InvalidTypeErr> &
       BaseRegExp<TState> &
-      Assert<HasNoOverlap, OverlapErr>
+      Assert<HasNoOverlap, OverlapErr>,
+    options?: AppenderOpts<Namespace, AsPrefix>
   ) => {
+    const opts = options ?? { namespace: "", asPrefix: true }
+    const prefix = (opts.asPrefix ? opts.namespace : "") as Prefix
+    const suffix = (opts.asPrefix ? "" : opts.namespace) as Suffix
     const newState = instance.getState()
+    const namespacedState = this.namespaceState(newState, prefix, suffix)
+
     return new TypedRegExp(
       this.merge({
-        msg: newState.msg,
-        curExp: newState.curExp,
-        prvExp: `${this.state.prvExp}${this.state.curExp}${newState.prvExp}`,
-        names: [...this.state.names, ...newState.names],
-        groups: [...this.state.groups, ...newState.groups],
+        msg: namespacedState.msg,
+        curExp: namespacedState.curExp,
+        prvExp: `${this.state.prvExp}${this.state.curExp}${namespacedState.prvExp}`,
+        names: [...this.state.names, ...namespacedState.names],
+        groups: [...this.state.groups, ...namespacedState.groups],
       })
     )
+  }
+
+  backreferenceTo = <
+    PossibleRefs extends (string | number)[] = GroupReferences<
+      CurState["names"],
+      CurState["groups"]
+    >,
+    Ref extends string | number = PossibleRefs[number],
+    IsValidRef = Ref extends PossibleRefs[number] ? true : false,
+    InvalidRefErr = `❌ The Reference '${Ref}' is not a valid backreference. Possible values include: ${Join<PossibleRefs>}`,
+    RefType extends string = Ref extends string ? `\\k<${Ref}>` : `\\${Ref}`
+  >(
+    ref: Assert<IsValidRef, InvalidRefErr> & Ref
+  ) => {
+    const refType = (typeof ref === "string" ? `\\k<${ref}>` : `\\${ref}`) as RefType
+    return new TypedRegExp(this.merge({ curExp: `${this.state.curExp}${refType}` }))
   }
 
   static create() {

--- a/src/Characters.test.ts
+++ b/src/Characters.test.ts
@@ -1,15 +1,6 @@
 import { createState } from "@utils"
 import { describe, expect, it } from "vitest"
-import {
-  anyChar,
-  capture,
-  controlChar,
-  hexCode,
-  match,
-  namedCapture,
-  unicodeChar,
-  wordChar,
-} from "./index"
+import { anyChar, controlChar, hexCode, unicodeChar, wordChar } from "./index"
 
 describe("characters", () => {
   describe("anyChar", () => {
@@ -58,27 +49,6 @@ describe("characters", () => {
     it("works", () => {
       const test = wordChar
       expect(test.getState()).toMatchObject(createState({ curExp: "\\w" }))
-    })
-  })
-
-  describe("backreferenceTo", () => {
-    it("works with a numbered reference", () => {
-      const test = capture(match.anyChar).and.backreferenceTo(1)
-      expect(test.getState()).toMatchObject(
-        createState({ curExp: "\\1", prvExp: "(.)", groups: ["(.)"] })
-      )
-    })
-
-    it("works with a named reference", () => {
-      const test = namedCapture("test", match.anyChar).and.backreferenceTo("test")
-      expect(test.getState()).toMatchObject(
-        createState({
-          curExp: "\\k<test>",
-          prvExp: "(?<test>.)",
-          names: ["test"],
-          groups: ["(?<test>.)"],
-        })
-      )
     })
   })
 })

--- a/src/Characters.ts
+++ b/src/Characters.ts
@@ -1,4 +1,4 @@
-import { Assert, GroupReferences, HexChar, Join, Letter, OfLength, State } from "@types"
+import { Assert, HexChar, Letter, OfLength, State } from "@types"
 import { createState } from "@utils"
 import { BaseRegExp } from "./BaseRegExp"
 import { TypedRegExp } from "./TypedRegExp"
@@ -48,22 +48,6 @@ export class Characters<CurState extends State> extends BaseRegExp<CurState> {
       Assert<IsProperLength, ImproperLengthErr>
   ) => {
     return new TypedRegExp(this.merge({ curExp: `${this.state.curExp}\\u{${unicodeChar}}` }))
-  }
-
-  backreferenceTo = <
-    PossibleRefs extends (string | number)[] = GroupReferences<
-      CurState["names"],
-      CurState["groups"]
-    >,
-    Ref extends string | number = PossibleRefs[number],
-    IsValidRef = Ref extends PossibleRefs[number] ? true : false,
-    InvalidRefErr = `❌ The Reference '${Ref}' is not a valid backreference. Possible values include: ${Join<PossibleRefs>}`,
-    RefType extends string = Ref extends string ? `\\k<${Ref}>` : `\\${Ref}`
-  >(
-    ref: Assert<IsValidRef, InvalidRefErr> & Ref
-  ) => {
-    const refType = (typeof ref === "string" ? `\\k<${ref}>` : `\\${ref}`) as RefType
-    return new TypedRegExp(this.merge({ curExp: `${this.state.curExp}${refType}` }))
   }
 
   static create() {

--- a/src/types/assertions.ts
+++ b/src/types/assertions.ts
@@ -1,4 +1,4 @@
-import { Add, Primitive, Subtract } from "@types"
+import { Add, Primitive, Subtract, Replace } from "@types"
 
 /**
  * A unique symbol used to brand error types
@@ -13,23 +13,6 @@ declare const brand: unique symbol
 declare interface Err<Token> {
   readonly [brand]: Token
 }
-
-/**
- * Replace all instances of a search string with a replacement string
- * @param Input The string to search
- * @param Replacement The string to replace the search string with
- * @param Search The string to search for
- * @returns The string with all instances of the search string replaced with the replacement string
- */
-export type Replace<
-  Input,
-  Replacement,
-  Search extends Primitive = "$"
-> = Input extends `${infer Head}${Search}${infer Tail}`
-  ? Replacement extends Primitive
-    ? `${Head}${Replacement}${Replace<Tail, Replacement, Search>}`
-    : Input
-  : Input
 
 /**
  * Assert that a type is true, otherwise throw an error

--- a/src/types/converters.ts
+++ b/src/types/converters.ts
@@ -55,3 +55,96 @@ export type Join<Tuple, Delimiter extends string = " | "> = Tuple extends [
 export type TupleToIntersection<T, U extends any[]> = U extends [infer First, ...infer Rest]
   ? T & TupleToIntersection<First, Rest>
   : T
+
+/**
+ * Replace all instances of a search string with a replacement string
+ * @param Input The string to search
+ * @param Replacement The string to replace the search string with
+ * @param Search The string to search for
+ * @returns The string with all instances of the search string replaced with the replacement string
+ */
+export type Replace<
+  Input,
+  Replacement,
+  Search extends Primitive = "$"
+> = Input extends `${infer Head}${Search}${infer Tail}`
+  ? Replacement extends Primitive
+    ? `${Head}${Replacement}${Replace<Tail, Replacement, Search>}`
+    : Input
+  : Input
+
+/**
+ * Wrap a primitive in a prefix and suffix
+ * @param Input The primitive to wrap
+ * @param Prefix The prefix to wrap the primitive with
+ * @param Suffix The suffix to wrap the primitive with
+ * @returns The wrapped primitive
+ */
+export type Wrap<
+  Input,
+  Prefix extends Primitive,
+  Suffix extends Primitive
+> = Input extends Primitive ? `${Prefix}${Input}${Suffix}` : Input extends Primitive ? Input : never
+
+/**
+ * Wrap all instances of a search string in a prefix and suffix
+ * @param Input The string to search
+ * @param Prefix The prefix to wrap the search string with
+ * @param Suffix The suffix to wrap the search string with
+ * @param PreSearch The string to search for before the search string
+ * @param PostSearch The string to search for after the search string
+ * @returns The string with all instances of the search string wrapped with the prefix and suffix
+ */
+export type WrapSearch<
+  Input,
+  Prefix extends Primitive,
+  Suffix extends Primitive,
+  PreSearch extends Primitive,
+  PostSearch extends Primitive
+> = Input extends `${infer Head}${PreSearch}${infer Middle}${PostSearch}${infer Tail}`
+  ? `${Head}${PreSearch}${Prefix}${Middle}${Suffix}${PostSearch}${WrapSearch<
+      Tail,
+      Prefix,
+      Suffix,
+      PreSearch,
+      PostSearch
+    >}`
+  : Input extends Primitive
+  ? Input
+  : never
+
+/**
+ * Map over a tuple and wrap each primitive in a prefix and suffix
+ * @param T The tuple to map over
+ * @param Prefix The prefix to wrap each primitive with
+ * @param Suffix The suffix to wrap each primitive with
+ * @returns The mapped tuple
+ */
+export type MapWrap<T, Prefix extends Primitive, Suffix extends Primitive> = T extends [
+  infer First,
+  ...infer Rest
+]
+  ? [Wrap<First, Prefix, Suffix>, ...MapWrap<Rest, Prefix, Suffix>]
+  : []
+
+/**
+ * Map over a tuple and wrap all instances of a search string in a prefix and suffix
+ * @param T The tuple to map over
+ * @param Prefix The prefix to wrap the search string with
+ * @param Suffix The suffix to wrap the search string with
+ * @param PreSearch The string to search for before the search string
+ * @param PostSearch The string to search for after the search string
+ * @returns The mapped tuple
+ */
+export type MapWrapSearch<
+  T,
+  Prefix extends Primitive,
+  Suffix extends Primitive,
+  PreSearch extends Primitive,
+  PostSearch extends Primitive
+> = T extends [infer First, ...infer Rest]
+  ? [
+      WrapSearch<First, Prefix, Suffix, PreSearch, PostSearch>,
+      ...MapWrapSearch<Rest, Prefix, Suffix, PreSearch, PostSearch>
+    ]
+  : []

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -35,6 +35,11 @@ type MergePrimitive<T, S> = [S] extends [never]
 
 /**
  * The State of a TypedRegExp
+ * @param Msg The message to use to help indicate the user what is going on
+ * @param CurExp The current expression
+ * @param PrvExp The previous expression
+ * @param Names The names of the groups
+ * @param Groups The groups
  */
 export interface State<
   Msg extends Primitive = Primitive,
@@ -50,6 +55,14 @@ export interface State<
   groups: [...Groups]
 }
 
+/**
+ * A helper type to infer the state of a TypedRegExp
+ * @param Msg The message to use to help indicate the user what is going on
+ * @param CurExp The current expression
+ * @param PrvExp The previous expression
+ * @param Names The names of the groups
+ * @param Groups The groups
+ */
 export interface InferState<
   TState extends State<Msg, CurExp, PrvExp, Names, Groups>,
   Msg extends Primitive = TState["msg"],
@@ -63,6 +76,19 @@ export interface InferState<
   prvExp: PrvExp
   names: [...Names]
   groups: [...Groups]
+}
+
+/**
+ * The options for an Appender
+ * @param Namespace The namespace to use for the appender
+ * @param AsPrefix Whether or not to use the namespace as a prefix or a suffix
+ */
+export interface AppenderOpts<
+  Namespace extends string = string,
+  AsPrefix extends boolean = boolean
+> {
+  namespace: Namespace
+  asPrefix: AsPrefix
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "skipLibCheck": true,
+    "noErrorTruncation": true,
     "baseUrl": "./src",
     "paths": {
       "@types": ["./types/index"],


### PR DESCRIPTION
Adds options to appenders that allow a prefix or suffix to be added to all named capture groups and any backreferences using those names.