### PR TITLE
Rename to Reggex

### DIFF
--- a/src/Appenders.ts
+++ b/src/Appenders.ts
@@ -10,58 +10,51 @@ import {
   OfLength,
   StartsWith,
   State,
-  MapWrapSearch,
-  WrapSearch,
+  NamespaceState,
 } from "@types"
 import { createState, DEFAULT_MESSAGE } from "@utils"
-import { BaseRegExp } from "./BaseRegExp"
-import { TypedRegExp } from "./TypedRegExp"
+import { BaseReggex } from "./BaseReggex"
+import { Reggex } from "./Reggex"
 
-export class Appenders<CurState extends State> extends BaseRegExp<CurState> {
+export class Appenders<CurState extends State> extends BaseReggex<CurState> {
   private namespaceState = <
     TState extends State,
     Prefix extends string = "",
-    Suffix extends string = "",
-    TCurExp = WrapSearch<TState["curExp"], Prefix, Suffix, "?<", ">">,
-    TPrvExp = WrapSearch<TState["prvExp"], Prefix, Suffix, "?<", ">">,
-    TGroups = MapWrapSearch<TState["groups"], Prefix, Suffix, "?<", ">">,
-    FinalNewNames = MapWrap<TState["names"], Prefix, Suffix>,
-    FinalCurExp = WrapSearch<TCurExp, Prefix, Suffix, "\\k<", ">">,
-    FinalPrvExp = WrapSearch<TPrvExp, Prefix, Suffix, "\\k<", ">">,
-    FinalGroups = MapWrapSearch<TGroups, Prefix, Suffix, "\\k<", ">">
+    Suffix extends string = ""
   >(
     state: TState,
     prefix: Prefix,
     suffix: Suffix
-  ) => {
-    const newCurExp = `${state.curExp}`
-      .replace(/\?<(.*?)>/g, `?<${prefix}$1${suffix}>`)
-      .replace(/\\k<(.*?)>/g, `\\k<${prefix}$1${suffix}>`)
-    const newPrvExp = `${state.prvExp}`
-      .replace(/\?<(.*?)>/g, `?<${prefix}$1${suffix}>`)
-      .replace(/\\k<(.*?)>/g, `\\k<${prefix}$1${suffix}>`)
-    const newNames = state.names.map((name) => `${prefix}${name}${suffix}`)
-    const newGroups = state.groups.map((group) =>
-      group
-        .replace(/\?<(.*?)>/g, `?<${prefix}$1${suffix}>`)
-        .replace(/\\k<(.*?)>/g, `\\k<${prefix}$1${suffix}>`)
-    )
+  ): NamespaceState<TState, Prefix, Suffix> => {
+    const matchGroup = /(?<!(?:\\))\(\?<(.+?)>/g
+    const matchRef = /(?<!(?:\\))\\k<(.*?)>/g
 
     return {
-      msg: state.msg as TState["msg"],
-      curExp: newCurExp as FinalCurExp,
-      prvExp: newPrvExp as FinalPrvExp,
-      names: newNames as FinalNewNames,
-      groups: newGroups as FinalGroups,
-    }
+      msg: state.msg,
+      curExp: `${state.curExp}`
+        .replace(matchGroup, `(?<${prefix}$1${suffix}>`)
+        .replace(matchRef, `\\k<${prefix}$1${suffix}>`),
+      prvExp: `${state.prvExp}`
+        .replace(matchGroup, `(?<${prefix}$1${suffix}>`)
+        .replace(matchRef, `\\k<${prefix}$1${suffix}>`),
+      names: state.names.map((name) => `${prefix}${name}${suffix}`),
+      groups: state.groups.map((group) =>
+        group
+          .replace(matchGroup, `(?<${prefix}$1${suffix}>`)
+          .replace(matchRef, `\\k<${prefix}$1${suffix}>`)
+      ),
+    } as NamespaceState<TState, Prefix, Suffix>
   }
 
   group = <
+    // parameter types
     TState extends State,
     Namespace extends string = "",
     AsPrefix extends boolean = true,
+    // return types
     Prefix extends string = AsPrefix extends true ? Namespace : "",
     Suffix extends string = AsPrefix extends true ? "" : Namespace,
+    // assertion types
     IsValidType = Contains<TState["msg"], typeof DEFAULT_MESSAGE>,
     InvalidTypeErr = `❌ Only finalized expressions ready for RegExp conversion can be appended`,
     HasNoOverlap = NoOverlap<MapWrap<TState["names"], Prefix, Suffix>, CurState["names"]>,
@@ -70,7 +63,7 @@ export class Appenders<CurState extends State> extends BaseRegExp<CurState> {
     >}`
   >(
     instance: Assert<IsValidType, InvalidTypeErr> &
-      BaseRegExp<TState> &
+      BaseReggex<TState> &
       Assert<HasNoOverlap, OverlapErr>,
     options?: AppenderOpts<Namespace, AsPrefix>
   ) => {
@@ -80,7 +73,7 @@ export class Appenders<CurState extends State> extends BaseRegExp<CurState> {
     const newState = instance.getState()
     const namespacedState = this.namespaceState(newState, prefix, suffix)
 
-    return new TypedRegExp(
+    return new Reggex(
       this.merge({
         msg: namespacedState.msg,
         curExp: `(?:${namespacedState.prvExp}${namespacedState.curExp})`,
@@ -92,11 +85,14 @@ export class Appenders<CurState extends State> extends BaseRegExp<CurState> {
   }
 
   capture = <
+    // parameter types
     TState extends State,
     Namespace extends string = "",
     AsPrefix extends boolean = true,
+    // return types
     Prefix extends string = AsPrefix extends true ? Namespace : "",
     Suffix extends string = AsPrefix extends true ? "" : Namespace,
+    // assertion types
     IsValidType = Contains<TState["msg"], typeof DEFAULT_MESSAGE>,
     InvalidTypeErr = `❌ Only finalized expressions ready for RegExp conversion can be appended`,
     HasNoOverlap = NoOverlap<MapWrap<TState["names"], Prefix, Suffix>, CurState["names"]>,
@@ -105,7 +101,7 @@ export class Appenders<CurState extends State> extends BaseRegExp<CurState> {
     >}`
   >(
     instance: Assert<IsValidType, InvalidTypeErr> &
-      BaseRegExp<TState> &
+      BaseReggex<TState> &
       Assert<HasNoOverlap, OverlapErr>,
     options?: AppenderOpts<Namespace, AsPrefix>
   ) => {
@@ -116,7 +112,8 @@ export class Appenders<CurState extends State> extends BaseRegExp<CurState> {
     const namespacedState = this.namespaceState(newState, prefix, suffix)
 
     const group = `(${namespacedState.prvExp}${namespacedState.curExp})` as const
-    return new TypedRegExp(
+
+    return new Reggex(
       this.merge({
         msg: namespacedState.msg,
         curExp: group,
@@ -128,12 +125,15 @@ export class Appenders<CurState extends State> extends BaseRegExp<CurState> {
   }
 
   namedCapture = <
+    // parameter types
     TState extends State,
     Name extends string,
     Namespace extends string = "",
     AsPrefix extends boolean = true,
+    // return types
     Prefix extends string = AsPrefix extends true ? Namespace : "",
     Suffix extends string = AsPrefix extends true ? "" : Namespace,
+    // assertion types
     NameIsNotEmpty = OfLength<Name, number>,
     NameEmptyErr = `❌ The Name '${Name}' must be a non-empty string`,
     NameStartsWithLetter = StartsWith<Name, Letter>,
@@ -157,7 +157,7 @@ export class Appenders<CurState extends State> extends BaseRegExp<CurState> {
       Assert<NameStartsWithLetter, NameDoesNotStartWithLetterErr> &
       Assert<NameHasNoOverlap, NameOverlapErr>,
     instance: Assert<IsValidType, InvalidTypeErr> &
-      BaseRegExp<TState> &
+      BaseReggex<TState> &
       Assert<InstanceHasNoOverlap, InstanceOverlapErr>,
     options?: AppenderOpts<Namespace, AsPrefix>
   ) => {
@@ -168,7 +168,8 @@ export class Appenders<CurState extends State> extends BaseRegExp<CurState> {
     const namespacedState = this.namespaceState(newState, prefix, suffix)
 
     const group = `(?<${name}>${namespacedState.prvExp}${namespacedState.curExp})` as const
-    return new TypedRegExp(
+
+    return new Reggex(
       this.merge({
         msg: namespacedState.msg,
         curExp: group,
@@ -180,11 +181,14 @@ export class Appenders<CurState extends State> extends BaseRegExp<CurState> {
   }
 
   append = <
+    // parameter types
     TState extends State,
     Namespace extends string = "",
     AsPrefix extends boolean = true,
+    // return types
     Prefix extends string = AsPrefix extends true ? Namespace : "",
     Suffix extends string = AsPrefix extends true ? "" : Namespace,
+    // assertion types
     IsValidType = Contains<TState["msg"], typeof DEFAULT_MESSAGE>,
     InvalidTypeErr = `❌ Only finalized expressions ready for RegExp conversion can be appended`,
     HasNoOverlap = NoOverlap<MapWrap<TState["names"], Prefix, Suffix>, CurState["names"]>,
@@ -193,7 +197,7 @@ export class Appenders<CurState extends State> extends BaseRegExp<CurState> {
     >}`
   >(
     instance: Assert<IsValidType, InvalidTypeErr> &
-      BaseRegExp<TState> &
+      BaseReggex<TState> &
       Assert<HasNoOverlap, OverlapErr>,
     options?: AppenderOpts<Namespace, AsPrefix>
   ) => {
@@ -203,7 +207,7 @@ export class Appenders<CurState extends State> extends BaseRegExp<CurState> {
     const newState = instance.getState()
     const namespacedState = this.namespaceState(newState, prefix, suffix)
 
-    return new TypedRegExp(
+    return new Reggex(
       this.merge({
         msg: namespacedState.msg,
         curExp: namespacedState.curExp,
@@ -215,23 +219,27 @@ export class Appenders<CurState extends State> extends BaseRegExp<CurState> {
   }
 
   backreferenceTo = <
+    // parameter types
     PossibleRefs extends (string | number)[] = GroupReferences<
       CurState["names"],
       CurState["groups"]
     >,
     Ref extends string | number = PossibleRefs[number],
+    // return types
+    RefType extends string = Ref extends string ? `\\k<${Ref}>` : `\\${Ref}`,
+    // assertion types
     IsValidRef = Ref extends PossibleRefs[number] ? true : false,
-    InvalidRefErr = `❌ The Reference '${Ref}' is not a valid backreference. Possible values include: ${Join<PossibleRefs>}`,
-    RefType extends string = Ref extends string ? `\\k<${Ref}>` : `\\${Ref}`
+    InvalidRefErr = `❌ The Reference '${Ref}' is not a valid backreference. Possible values include: ${Join<PossibleRefs>}`
   >(
     ref: Assert<IsValidRef, InvalidRefErr> & Ref
   ) => {
     const refType = (typeof ref === "string" ? `\\k<${ref}>` : `\\${ref}`) as RefType
-    return new TypedRegExp(this.merge({ curExp: `${this.state.curExp}${refType}` }))
+
+    return new Reggex(this.merge({ curExp: `${this.state.curExp}${refType}` }))
   }
 
   static create() {
-    const state = createState({ msg: "⏳ Select Input..." })
+    const state = createState({ msg: "⏳ Select Appender..." })
     return new Appenders(state)
   }
 }

--- a/src/BaseRegExp.ts
+++ b/src/BaseRegExp.ts
@@ -2,6 +2,11 @@ import { merger } from "@utils"
 import { InferState, State } from "./types/state"
 
 export class BaseRegExp<CurState extends State> {
+  /**
+   * Merge the current state with the new state
+   * @param newState The new state to merge with the default state
+   * @returns The merged state
+   */
   protected merge
 
   constructor(protected state: InferState<CurState>) {

--- a/src/BaseReggex.ts
+++ b/src/BaseReggex.ts
@@ -1,7 +1,7 @@
 import { merger } from "@utils"
 import { InferState, State } from "./types/state"
 
-export class BaseRegExp<CurState extends State> {
+export class BaseReggex<CurState extends State> {
   /**
    * Merge the current state with the new state
    * @param newState The new state to merge with the default state
@@ -13,6 +13,10 @@ export class BaseRegExp<CurState extends State> {
     this.merge = merger(this.state)
   }
 
+  /**
+   * Get the current state
+   * @returns The current state
+   */
   getState(): InferState<CurState> {
     return {
       msg: this.state.msg,
@@ -23,13 +27,19 @@ export class BaseRegExp<CurState extends State> {
     }
   }
 
+  /**
+   * Extend the class with a new method
+   * @param value The method to extend the class with
+   * @param options The options for the method (name, type)
+   * @returns The passed in method for type inference
+   */
   static extend<Return, ExtenderFunction extends (...args: any[]) => Return>(
     value: ExtenderFunction,
     options: {
       name: string
       type?: "getMethod" | "method" | "value"
     }
-  ) {
+  ): ExtenderFunction {
     Object.defineProperty(this.prototype, options.name, {
       [options.type === "getMethod" ? "get" : "value"]: value(),
     })

--- a/src/Characters.ts
+++ b/src/Characters.ts
@@ -1,15 +1,17 @@
-import { Assert, HexChar, Letter, OfLength, State } from "@types"
+import { Assert, HexChar, Letter, OfLength, State, StateMerger } from "@types"
 import { createState } from "@utils"
-import { BaseRegExp } from "./BaseRegExp"
-import { TypedRegExp } from "./TypedRegExp"
+import { BaseReggex } from "./BaseReggex"
+import { Reggex } from "./Reggex"
 
-export class Characters<CurState extends State> extends BaseRegExp<CurState> {
-  get anyChar() {
-    return new TypedRegExp(this.merge({ curExp: `${this.state.curExp}.` }))
+export class Characters<CurState extends State> extends BaseReggex<CurState> {
+  get anyChar(): Reggex<
+    StateMerger<CurState, State<never, `${CurState["curExp"]}.`, never, never, never>>
+  > {
+    return new Reggex(this.merge({ curExp: `${this.state.curExp}.` }))
   }
 
   get wordChar() {
-    return new TypedRegExp(this.merge({ curExp: `${this.state.curExp}\\w` }))
+    return new Reggex(this.merge({ curExp: `${this.state.curExp}\\w` }))
   }
 
   controlChar = <
@@ -19,7 +21,7 @@ export class Characters<CurState extends State> extends BaseRegExp<CurState> {
   >(
     controlChar: ControlChar & Assert<IsLetter, NotLetterErr>
   ) => {
-    return new TypedRegExp(this.merge({ curExp: `${this.state.curExp}\\c${controlChar}` }))
+    return new Reggex(this.merge({ curExp: `${this.state.curExp}\\c${controlChar}` }))
   }
 
   hexCode = <
@@ -33,7 +35,7 @@ export class Characters<CurState extends State> extends BaseRegExp<CurState> {
     hexChars: HexCode & Assert<IsHexChar, HexCharErr> & Assert<IsProperLength, ImproperLengthErr>
   ) => {
     const charType = (hexChars.length === 2 ? "\\x" : "\\u") as CharType
-    return new TypedRegExp(this.merge({ curExp: `${this.state.curExp}${charType}${hexChars}` }))
+    return new Reggex(this.merge({ curExp: `${this.state.curExp}${charType}${hexChars}` }))
   }
 
   unicodeChar = <
@@ -47,7 +49,7 @@ export class Characters<CurState extends State> extends BaseRegExp<CurState> {
       Assert<IsHexChar, HexCharErr> &
       Assert<IsProperLength, ImproperLengthErr>
   ) => {
-    return new TypedRegExp(this.merge({ curExp: `${this.state.curExp}\\u{${unicodeChar}}` }))
+    return new Reggex(this.merge({ curExp: `${this.state.curExp}\\u{${unicodeChar}}` }))
   }
 
   static create() {

--- a/src/Groups.ts
+++ b/src/Groups.ts
@@ -1,15 +1,15 @@
 import { Assert, Join, Letter, NoOverlap, OfLength, StartsWith, State } from "@types"
-import { BaseRegExp } from "./BaseRegExp"
-import { TypedRegExp } from "./TypedRegExp"
+import { BaseReggex } from "./BaseReggex"
+import { Reggex } from "./Reggex"
 
-export class Groups<CurState extends State> extends BaseRegExp<CurState> {
+export class Groups<CurState extends State> extends BaseReggex<CurState> {
   get nonCapture() {
-    return new TypedRegExp(this.merge({ curExp: `(?:${this.state.curExp})` }))
+    return new Reggex(this.merge({ curExp: `(?:${this.state.curExp})` }))
   }
 
   get capture() {
     const group = `(${this.state.curExp})` as const
-    return new TypedRegExp(this.merge({ curExp: group, groups: [...this.state.groups, group] }))
+    return new Reggex(this.merge({ curExp: group, groups: [...this.state.groups, group] }))
   }
 
   namedCapture = <
@@ -29,7 +29,7 @@ export class Groups<CurState extends State> extends BaseRegExp<CurState> {
       Assert<HasNoOverlap, OverlapErr>
   ) => {
     const group = `(?<${name}>${this.state.curExp})` as const
-    return new TypedRegExp(
+    return new Reggex(
       this.merge({
         curExp: group,
         names: [...this.state.names, name],

--- a/src/Quantifiers.ts
+++ b/src/Quantifiers.ts
@@ -1,18 +1,18 @@
 import { Contains, State } from "@types"
-import { BaseRegExp } from "./BaseRegExp"
-import { TypedRegExp } from "./TypedRegExp"
+import { BaseReggex } from "./BaseReggex"
+import { Reggex } from "./Reggex"
 
 export class Quantifiers<
   CurState extends State,
   IsLazy extends string = Contains<CurState["msg"], "lazy"> extends true ? "?" : ""
-> extends BaseRegExp<CurState> {
+> extends BaseReggex<CurState> {
   private isLazy = (String(this.state.msg).includes("lazy") ? "?" : "") as IsLazy
 
   get zeroOrMore() {
-    return new TypedRegExp(this.merge({ curExp: `${this.state.curExp}*${this.isLazy}` }))
+    return new Reggex(this.merge({ curExp: `${this.state.curExp}*${this.isLazy}` }))
   }
 
   get oneOrMore() {
-    return new TypedRegExp(this.merge({ curExp: `${this.state.curExp}+${this.isLazy}` }))
+    return new Reggex(this.merge({ curExp: `${this.state.curExp}+${this.isLazy}` }))
   }
 }

--- a/src/Reggex.test.ts
+++ b/src/Reggex.test.ts
@@ -1,7 +1,7 @@
 import { GetMethod, RegularMethod } from "@types"
 import { createState, DEFAULT_MESSAGE } from "@utils"
 import { describe, expect, it } from "vitest"
-import { Characters, match, State, TypedRegExp } from "./index"
+import { Characters, match, State, Reggex } from "./index"
 
 declare module "./Characters" {
   interface Characters<CurState extends State> {
@@ -14,7 +14,7 @@ declare module "./Characters" {
 const gmailDomain = Characters.extend(
   <CurState extends State>() => {
     return function (this: Characters<CurState>) {
-      return new TypedRegExp(this.merge({ curExp: `${this.state.curExp}\\bgmail.com\\b` }))
+      return new Reggex(this.merge({ curExp: `${this.state.curExp}\\bgmail.com\\b` }))
     }
   },
   { name: "gmailDomain", type: "getMethod" }
@@ -23,7 +23,7 @@ const gmailDomain = Characters.extend(
 const domain = Characters.extend(
   <CurState extends State>() => {
     return function <Domain extends string>(this: Characters<CurState>, domain: Domain) {
-      return new TypedRegExp(
+      return new Reggex(
         this.merge({
           curExp: `${this.state.curExp}\\b${domain}\\b`,
           groups: [...this.state.groups, "test"],
@@ -41,7 +41,7 @@ const helloString = Characters.extend(
   { name: "helloString", type: "value" }
 )
 
-describe("TypedRegExp", () => {
+describe("Reggex", () => {
   describe("DEFAULT_MESSAGE", () => {
     it("is a string", () => {
       expect(typeof DEFAULT_MESSAGE).toBe("string")

--- a/src/Reggex.ts
+++ b/src/Reggex.ts
@@ -1,12 +1,12 @@
 import { State } from "@types"
 import { assign } from "@utils"
-import { BaseRegExp } from "./BaseRegExp"
+import { BaseReggex } from "./BaseReggex"
 import { Groups } from "./Groups"
 import { Appenders } from "./Appenders"
 import { Characters } from "./Characters"
 import { Quantifiers } from "./Quantifiers"
 
-export class TypedRegExp<CurState extends State> extends BaseRegExp<CurState> {
+export class Reggex<CurState extends State> extends BaseReggex<CurState> {
   get thatOccurs() {
     const greedyState = this.merge({ msg: "⏳️ Select greedy Quantifier..." })
     const lazyState = this.merge({ msg: "⏳️ Select lazy Quantifier..." })

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export * from "./Groups"
 export * from "./Appenders"
 export * from "./Characters"
 export * from "./Quantifiers"
-export * from "./TypedRegExp"
+export * from "./Reggex"
 
 export const anyChar = Characters.create().anyChar
 export const controlChar = Characters.create().controlChar

--- a/src/types/converters.ts
+++ b/src/types/converters.ts
@@ -102,13 +102,17 @@ export type WrapSearch<
   PreSearch extends Primitive,
   PostSearch extends Primitive
 > = Input extends `${infer Head}${PreSearch}${infer Middle}${PostSearch}${infer Tail}`
-  ? `${Head}${PreSearch}${Prefix}${Middle}${Suffix}${PostSearch}${WrapSearch<
-      Tail,
-      Prefix,
-      Suffix,
-      PreSearch,
-      PostSearch
-    >}`
+  ? Head extends `${string}\\`
+    ? Input extends Primitive
+      ? Input
+      : never
+    : `${Head}${PreSearch}${Prefix}${Middle}${Suffix}${PostSearch}${WrapSearch<
+        Tail,
+        Prefix,
+        Suffix,
+        PreSearch,
+        PostSearch
+      >}`
   : Input extends Primitive
   ? Input
   : never

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -1,4 +1,4 @@
-import { Expand, Length, MapAdd, Primitive } from "@types"
+import { Expand, Length, MapAdd, MapWrap, MapWrapSearch, Primitive, WrapSearch } from "@types"
 import { DEFAULT_MESSAGE } from "@utils"
 
 /**
@@ -34,7 +34,7 @@ type MergePrimitive<T, S> = [S] extends [never]
   : never
 
 /**
- * The State of a TypedRegExp
+ * The State of a Reggex
  * @param Msg The message to use to help indicate the user what is going on
  * @param CurExp The current expression
  * @param PrvExp The previous expression
@@ -56,7 +56,7 @@ export interface State<
 }
 
 /**
- * A helper type to infer the state of a TypedRegExp
+ * A helper type to infer the state of a Reggex
  * @param Msg The message to use to help indicate the user what is going on
  * @param CurExp The current expression
  * @param PrvExp The previous expression
@@ -130,3 +130,28 @@ export type GroupReferences<Names extends Primitive[], Groups extends Primitive[
   ...Names,
   ...MapAdd<TupleIndices<Groups>, 1>
 ]
+
+/**
+ *  Namespace named capture groups with a prefix or suffix
+ * @param TState The state to namespace
+ * @param Prefix The prefix to use
+ * @param Suffix The suffix to use
+ * @returns Namespaced state
+ */
+export type NamespaceState<
+  TState extends State,
+  Prefix extends string = "",
+  Suffix extends string = ""
+> = State<
+  TState["msg"],
+  WrapSearch<WrapSearch<TState["curExp"], Prefix, Suffix, "?<", ">">, Prefix, Suffix, "\\k<", ">">,
+  WrapSearch<WrapSearch<TState["prvExp"], Prefix, Suffix, "?<", ">">, Prefix, Suffix, "\\k<", ">">,
+  MapWrap<TState["names"], Prefix, Suffix>,
+  MapWrapSearch<
+    MapWrapSearch<TState["groups"], Prefix, Suffix, "?<", ">">,
+    Prefix,
+    Suffix,
+    "\\k<",
+    ">"
+  >
+>

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -1,10 +1,81 @@
-import { assign } from "@utils"
+import { assign, createState, merger } from "@utils"
 import { describe, it, expect } from "vitest"
 
 const method = Symbol("method")
 const property = Symbol("property")
 
 describe("utils", () => {
+  describe("createState", () => {
+    it("creates a new state object", () => {
+      const test = createState()
+      expect(test.msg).toBeTypeOf("string")
+      expect(test.curExp).toBeTypeOf("string")
+      expect(test.prvExp).toBeTypeOf("string")
+      expect(test.names).toHaveLength(0)
+      expect(test.groups).toHaveLength(0)
+    })
+
+    it("creates a new state object based on the given state", () => {
+      const test = createState({
+        msg: "test",
+        curExp: "test",
+        prvExp: "test",
+        names: ["test"],
+        groups: ["test"],
+      })
+
+      expect(test.msg).toBe("test")
+      expect(test.curExp).toBe("test")
+      expect(test.prvExp).toBe("test")
+      expect(test.names).toHaveLength(1)
+      expect(test.groups).toHaveLength(1)
+    })
+  })
+
+  describe("merger", () => {
+    it("merges the msg appropriately", () => {
+      const merge = merger(createState({ msg: "test" }))
+      expect(merge({ msg: "test2" }).msg).toEqual("test2")
+      expect(merge({ msg: "" }).msg).toEqual("")
+      expect(merge({ msg: 0 }).msg).toEqual(0)
+      expect(merge({ msg: null }).msg).toEqual(createState().msg)
+      expect(merge({ msg: undefined }).msg).toEqual(createState().msg)
+      expect(merge({}).msg).toEqual(createState().msg)
+    })
+
+    it("merges the curExp appropriately", () => {
+      const merge = merger(createState({ curExp: "test" }))
+      expect(merge({ curExp: "test2" }).curExp).toEqual("test2")
+      expect(merge({ curExp: "" }).curExp).toEqual("")
+      expect(merge({ curExp: undefined }).curExp).toEqual("test")
+      expect(merge({}).curExp).toEqual("test")
+    })
+
+    it("merges the prvExp appropriately", () => {
+      const merge = merger(createState({ prvExp: "test" }))
+      expect(merge({ prvExp: "test2" }).prvExp).toEqual("test2")
+      expect(merge({ prvExp: "" }).prvExp).toEqual("")
+      expect(merge({ prvExp: undefined }).prvExp).toEqual("test")
+      expect(merge({}).prvExp).toEqual("test")
+    })
+
+    it("merges the names appropriately", () => {
+      const merge = merger(createState({ names: ["test"] }))
+      expect(merge({ names: ["test2"] }).names).toEqual(["test2"])
+      expect(merge({ names: [] }).names).toEqual([])
+      expect(merge({ names: undefined }).names).toEqual(["test"])
+      expect(merge({}).names).toEqual(["test"])
+    })
+
+    it("merges the groups appropriately", () => {
+      const merge = merger(createState({ groups: ["test"] }))
+      expect(merge({ groups: ["test2"] }).groups).toEqual(["test2"])
+      expect(merge({ groups: [] }).groups).toEqual([])
+      expect(merge({ groups: undefined }).groups).toEqual(["test"])
+      expect(merge({}).groups).toEqual(["test"])
+    })
+  })
+
   describe("assign", () => {
     class TestClass {
       public b = 2;


### PR DESCRIPTION
- Renames TypedRegExp to Reggex
- Renames BaseRegExp to BaseReggex
- Fixes issue with escaped characters still being namespaced when using an appender