### PR TITLE
Add transform plugin

### DIFF
--- a/.changeset/giant-rabbits-promise.md
+++ b/.changeset/giant-rabbits-promise.md
@@ -1,0 +1,5 @@
+---
+"reggex": minor
+---
+
+Add the ability to compile a Reggex to a TypedRegExp

--- a/.changeset/lovely-ads-applaud.md
+++ b/.changeset/lovely-ads-applaud.md
@@ -1,0 +1,7 @@
+---
+"reggex": minor
+---
+
+Add transformer plugin to pre-compile a Reggex into a RegExp to completely remove any performance overhead that is added by this library
+
+Note: This assumes that the `compileReggex()` function is used instead of the `.compile()` method and that the function passed to `compileReggex` does not have any side-effects. If the function passed to `compileReggex` has side-effects, it will be left as-is since `reggex` is completely functional at run-time.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   ],
   "tsup": {
     "entry": [
-      "src/index.ts"
+      "src/index.ts",
+      "src/transform.ts"
     ],
     "treeshake": true,
     "minify": true,
@@ -38,7 +39,13 @@
   "exports": {
     ".": {
       "require": "./lib/index.cjs",
-      "import": "./lib/index.js"
+      "import": "./lib/index.js",
+      "types": "./lib/index.d.ts"
+    },
+    "./transform": {
+      "require": "./lib/transform.cjs",
+      "import": "./lib/transform.js",
+      "types": "./lib/transform.d.ts"
     }
   },
   "files": [
@@ -63,7 +70,15 @@
     "prettier": "2.8.4",
     "tsup": "^6.6.3",
     "typescript": "^4.9.5",
-    "vitest": "^0.29.1",
-    "vite-tsconfig-paths": "^4.0.5"
+    "vite-tsconfig-paths": "^4.0.5",
+    "vitest": "^0.29.1"
+  },
+  "dependencies": {
+    "@types/estree": "^1.0.0",
+    "acorn": "^8.8.2",
+    "estree-walker": "^3.0.3",
+    "magic-string": "^0.30.0",
+    "mlly": "^1.1.1",
+    "unplugin": "^1.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,17 +2,31 @@ lockfileVersion: 5.4
 
 specifiers:
   '@changesets/cli': ^2.26.0
+  '@types/estree': ^1.0.0
   '@types/node': ^18.14.1
   '@typescript-eslint/eslint-plugin': ^5.53.0
   '@typescript-eslint/parser': ^5.53.0
   '@vitest/coverage-c8': ^0.29.1
+  acorn: ^8.8.2
   eslint: ^8.34.0
   eslint-config-prettier: ^8.6.0
+  estree-walker: ^3.0.3
+  magic-string: ^0.30.0
+  mlly: ^1.1.1
   prettier: 2.8.4
   tsup: ^6.6.3
   typescript: ^4.9.5
+  unplugin: ^1.1.0
   vite-tsconfig-paths: ^4.0.5
   vitest: ^0.29.1
+
+dependencies:
+  '@types/estree': 1.0.0
+  acorn: 8.8.2
+  estree-walker: 3.0.3
+  magic-string: 0.30.0
+  mlly: 1.1.1
+  unplugin: 1.1.0
 
 devDependencies:
   '@changesets/cli': 2.26.0
@@ -691,7 +705,6 @@ packages:
 
   /@jridgewell/sourcemap-codec/1.4.14:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
-    dev: true
 
   /@jridgewell/trace-mapping/0.3.17:
     resolution: {integrity: sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==}
@@ -750,6 +763,10 @@ packages:
   /@types/chai/4.3.4:
     resolution: {integrity: sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==}
     dev: true
+
+  /@types/estree/1.0.0:
+    resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
+    dev: false
 
   /@types/is-ci/3.0.0:
     resolution: {integrity: sha512-Q0Op0hdWbYd1iahB+IFNQcWXFq4O0Q5MwQP7uN0souuQ4rPg1vEYcnIOfr1gY+M+6rc8FGoRaBO1mOOvL29sEQ==}
@@ -979,7 +996,6 @@ packages:
     resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-    dev: true
 
   /ajv/6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -1039,7 +1055,6 @@ packages:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
-    dev: true
 
   /argparse/1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -1094,7 +1109,6 @@ packages:
   /binary-extensions/2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
     engines: {node: '>=8'}
-    dev: true
 
   /brace-expansion/1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -1108,7 +1122,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       fill-range: 7.0.1
-    dev: true
 
   /breakword/1.0.5:
     resolution: {integrity: sha512-ex5W9DoOQ/LUEU3PMdLs9ua/CYZl1678NUkKOdUSi8Aw5F1idieaiRURCBFJCwVcrD1J8Iy3vfWSloaMwO2qFg==}
@@ -1227,7 +1240,6 @@ packages:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
 
   /ci-info/3.8.0:
     resolution: {integrity: sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==}
@@ -1714,6 +1726,12 @@ packages:
     engines: {node: '>=4.0'}
     dev: true
 
+  /estree-walker/3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+    dependencies:
+      '@types/estree': 1.0.0
+    dev: false
+
   /esutils/2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1788,7 +1806,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       to-regex-range: 5.0.1
-    dev: true
 
   /find-up/4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -1866,7 +1883,6 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /function-bind/1.1.1:
@@ -1922,7 +1938,6 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       is-glob: 4.0.3
-    dev: true
 
   /glob-parent/6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -2136,7 +2151,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       binary-extensions: 2.2.0
-    dev: true
 
   /is-boolean-object/1.1.2:
     resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==}
@@ -2174,7 +2188,6 @@ packages:
   /is-extglob/2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /is-fullwidth-code-point/3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
@@ -2191,7 +2204,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extglob: 2.1.1
-    dev: true
 
   /is-negative-zero/2.0.2:
     resolution: {integrity: sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==}
@@ -2208,7 +2220,6 @@ packages:
   /is-number/7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
-    dev: true
 
   /is-path-inside/3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
@@ -2350,7 +2361,6 @@ packages:
 
   /jsonc-parser/3.2.0:
     resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
-    dev: true
 
   /jsonfile/4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -2451,6 +2461,13 @@ packages:
       yallist: 4.0.0
     dev: true
 
+  /magic-string/0.30.0:
+    resolution: {integrity: sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.14
+    dev: false
+
   /make-dir/3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
     engines: {node: '>=8'}
@@ -2539,7 +2556,6 @@ packages:
       pathe: 1.1.0
       pkg-types: 1.0.2
       ufo: 1.1.0
-    dev: true
 
   /ms/2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
@@ -2579,7 +2595,6 @@ packages:
   /normalize-path/3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /npm-run-path/4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
@@ -2741,7 +2756,6 @@ packages:
 
   /pathe/1.1.0:
     resolution: {integrity: sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==}
-    dev: true
 
   /pathval/1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
@@ -2754,7 +2768,6 @@ packages:
   /picomatch/2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
-    dev: true
 
   /pify/4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
@@ -2779,7 +2792,6 @@ packages:
       jsonc-parser: 3.2.0
       mlly: 1.1.1
       pathe: 1.1.0
-    dev: true
 
   /postcss-load-config/3.1.4:
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
@@ -2892,7 +2904,6 @@ packages:
     engines: {node: '>=8.10.0'}
     dependencies:
       picomatch: 2.3.1
-    dev: true
 
   /redent/3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -3303,7 +3314,6 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
-    dev: true
 
   /tr46/1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
@@ -3450,7 +3460,6 @@ packages:
 
   /ufo/1.1.0:
     resolution: {integrity: sha512-LQc2s/ZDMaCN3QLpa+uzHUOQ7SdV0qgv3VBXOolQGXTaaZpIur6PwUclF5nN2hNkiTRcUugXd1zFOW3FLJ135Q==}
-    dev: true
 
   /unbox-primitive/1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
@@ -3465,6 +3474,15 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
     dev: true
+
+  /unplugin/1.1.0:
+    resolution: {integrity: sha512-I8obQ8Rs/hnkxokRV6g8JKOQFgYNnTd9DL58vcSt5IJ9AkK8wbrtsnzD5hi4BJlvcY536JzfEXj9L6h7j559/A==}
+    dependencies:
+      acorn: 8.8.2
+      chokidar: 3.5.3
+      webpack-sources: 3.2.3
+      webpack-virtual-modules: 0.5.0
+    dev: false
 
   /uri-js/4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -3618,6 +3636,15 @@ packages:
   /webidl-conversions/4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
     dev: true
+
+  /webpack-sources/3.2.3:
+    resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
+    engines: {node: '>=10.13.0'}
+    dev: false
+
+  /webpack-virtual-modules/0.5.0:
+    resolution: {integrity: sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==}
+    dev: false
 
   /whatwg-url/7.1.0:
     resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}

--- a/src/Appenders.test.ts
+++ b/src/Appenders.test.ts
@@ -10,17 +10,17 @@ describe("Appenders", () => {
           .namedCapture("test")
           .and.group(
             match.anyChar.and.wordChar.groupedAs.namedCapture("test").and.backreferenceTo("test"),
-            { namespace: "prefix-", asPrefix: true }
+            { namespace: "pre", asPrefix: true }
           ),
-        { namespace: "-suffix", asPrefix: false }
+        { namespace: "suf", asPrefix: false }
       )
 
       expect(test.getState()).toMatchObject(
         createState({
-          curExp: "(?:(?<test-suffix>.)(?:.(?<prefix-test-suffix>\\w)\\k<prefix-test-suffix>))",
+          curExp: "(?:(?<testsuf>.)(?:.(?<pretestsuf>\\w)\\k<pretestsuf>))",
           prvExp: "",
-          names: ["test-suffix", "prefix-test-suffix"],
-          groups: ["(?<test-suffix>.)", "(?<prefix-test-suffix>\\w)"]
+          names: ["testsuf", "pretestsuf"],
+          groups: ["(?<testsuf>.)", "(?<pretestsuf>\\w)"]
         })
       )
     })
@@ -30,22 +30,18 @@ describe("Appenders", () => {
     it("works", () => {
       const test = capture(
         capture(match.anyChar.and.wordChar.as.namedCapture("test"), {
-          namespace: "prefix-",
+          namespace: "pre",
           asPrefix: true
         }),
-        { namespace: "-suffix", asPrefix: false }
+        { namespace: "suf", asPrefix: false }
       )
 
       expect(test.getState()).toMatchObject(
         createState({
-          curExp: "((.(?<prefix-test-suffix>\\w)))",
+          curExp: "((.(?<pretestsuf>\\w)))",
           prvExp: "",
-          names: ["prefix-test-suffix"],
-          groups: [
-            "((.(?<prefix-test-suffix>\\w)))",
-            "(.(?<prefix-test-suffix>\\w))",
-            "(?<prefix-test-suffix>\\w)"
-          ]
+          names: ["pretestsuf"],
+          groups: ["((.(?<pretestsuf>\\w)))", "(.(?<pretestsuf>\\w))", "(?<pretestsuf>\\w)"]
         })
       )
     })
@@ -58,20 +54,20 @@ describe("Appenders", () => {
         namedCapture(
           "test",
           match.anyChar.and.wordChar.thatRepeats.greedily.oneOrMore.groupedAs.namedCapture("bro"),
-          { namespace: "prefix-", asPrefix: true }
+          { namespace: "pre", asPrefix: true }
         ).and.anyChar.as.capture.and.group(match.anyChar.and.wordChar),
-        { namespace: "-suffix", asPrefix: false }
+        { namespace: "suf", asPrefix: false }
       )
 
       expect(test.getState()).toMatchObject(
         createState({
-          curExp: "(?<test>(?<test-suffix>.(?<prefix-bro-suffix>\\w+))(.)(?:.\\w))",
+          curExp: "(?<test>(?<testsuf>.(?<prebrosuf>\\w+))(.)(?:.\\w))",
           prvExp: "",
-          names: ["test", "test-suffix", "prefix-bro-suffix"],
+          names: ["test", "testsuf", "prebrosuf"],
           groups: [
-            "(?<test>(?<test-suffix>.(?<prefix-bro-suffix>\\w+))(.)(?:.\\w))",
-            "(?<test-suffix>.(?<prefix-bro-suffix>\\w+))",
-            "(?<prefix-bro-suffix>\\w+)",
+            "(?<test>(?<testsuf>.(?<prebrosuf>\\w+))(.)(?:.\\w))",
+            "(?<testsuf>.(?<prebrosuf>\\w+))",
+            "(?<prebrosuf>\\w+)",
             "(.)"
           ]
         })
@@ -85,20 +81,20 @@ describe("Appenders", () => {
         .namedCapture("test")
         .and.append(match.anyChar)
         .and.append(match.anyChar.as.namedCapture("test"), {
-          namespace: "prefix-",
+          namespace: "pre",
           asPrefix: true
         })
         .and.append(match.anyChar.as.namedCapture("test"), {
-          namespace: "-suffix",
+          namespace: "suf",
           asPrefix: false
         })
 
       expect(test.getState()).toMatchObject(
         createState({
-          curExp: "(?<test-suffix>.)",
-          prvExp: "(?<test>.).(?<prefix-test>.)",
-          names: ["test", "prefix-test", "test-suffix"],
-          groups: ["(?<test>.)", "(?<prefix-test>.)", "(?<test-suffix>.)"]
+          curExp: "(?<testsuf>.)",
+          prvExp: "(?<test>.).(?<pretest>.)",
+          names: ["test", "pretest", "testsuf"],
+          groups: ["(?<test>.)", "(?<pretest>.)", "(?<testsuf>.)"]
         })
       )
     })

--- a/src/BaseReggex.ts
+++ b/src/BaseReggex.ts
@@ -1,5 +1,5 @@
+import { Flag, InferState, Join, State, TypedRegExp } from "@types"
 import { merger } from "@utils"
-import { InferState, State } from "./types/state"
 
 export class BaseReggex<CurState extends State> {
   /**
@@ -46,4 +46,22 @@ export class BaseReggex<CurState extends State> {
 
     return value
   }
+
+  compile<
+    Flags extends Flag[] = [],
+    FinalFlags extends string = Join<Flags, "", "", false>,
+    FinalExpression extends string = `/${CurState["prvExp"]}${CurState["curExp"]}/${FinalFlags}`
+  >(flags?: [...Flags]): TypedRegExp<FinalExpression> {
+    const exp = `${this.state.prvExp}${this.state.curExp}`
+    const flagsString = (flags ?? []).join("")
+    return new RegExp(exp, flagsString) as TypedRegExp<FinalExpression>
+  }
 }
+
+export const global = "g"
+export const ignoreCase = "i"
+export const multiline = "m"
+export const dotAll = "s"
+export const unicode = "u"
+export const sticky = "y"
+export const hasIndices = "d"

--- a/src/Inputs.ts
+++ b/src/Inputs.ts
@@ -1,12 +1,10 @@
-import { Assert, HexChar, Letter, OfLength, State, StateMerger } from "@types"
+import { Assert, HexChar, Letter, OfLength, State } from "@types"
 import { createState } from "@utils"
 import { BaseReggex } from "./BaseReggex"
 import { Reggex } from "./Reggex"
 
 export class Inputs<CurState extends State> extends BaseReggex<CurState> {
-  get anyChar(): Reggex<
-    StateMerger<CurState, State<never, `${CurState["curExp"]}.`, never, never, never>>
-  > {
+  get anyChar() {
     return new Reggex(this.merge({ curExp: `${this.state.curExp}.` }))
   }
 

--- a/src/Reggex.test.ts
+++ b/src/Reggex.test.ts
@@ -1,7 +1,7 @@
 import { GetMethod, RegularMethod } from "@types"
 import { createState, DEFAULT_MESSAGE } from "@utils"
 import { describe, expect, it } from "vitest"
-import { Inputs, match, State, Reggex } from "./index"
+import { Inputs, match, State, Reggex, global, multiline } from "./index"
 
 declare module "./Inputs" {
   interface Inputs<CurState extends State> {
@@ -25,8 +25,8 @@ const domain = Inputs.extend(
     return function <Domain extends string>(this: Inputs<CurState>, domain: Domain) {
       return new Reggex(
         this.merge({
-          curExp: `${this.state.curExp}\\b${domain}\\b`,
-          groups: [...this.state.groups, "test"]
+          curExp: `${this.state.curExp}(\\b${domain}\\b)`,
+          groups: [...this.state.groups, `(\\b${domain}\\b)`]
         })
       )
     }
@@ -69,7 +69,11 @@ describe("Reggex", () => {
       const test = match.domain("test.com").and.domain("bro.com")
 
       expect(test.getState()).toEqual(
-        createState({ curExp: "\\bbro.com\\b", prvExp: "\\btest.com\\b", groups: ["test", "test"] })
+        createState({
+          curExp: "(\\bbro.com\\b)",
+          prvExp: "(\\btest.com\\b)",
+          groups: ["(\\btest.com\\b)", "(\\bbro.com\\b)"]
+        })
       )
     })
 
@@ -77,6 +81,34 @@ describe("Reggex", () => {
       const test = match.anyChar.and.helloString
 
       expect(test).toEqual("hello")
+    })
+  })
+
+  describe("compile", () => {
+    it("compiles the expression with flags", () => {
+      const test = match.anyChar.and.wordChar.and.anyChar.compile([multiline, global])
+
+      expect(test).toEqual(/.\w./gm)
+    })
+
+    it("compiles the expression without flags", () => {
+      const test = match.anyChar.and.wordChar.and.anyChar.compile()
+
+      expect(test).toEqual(/.\w./)
+    })
+
+    it("compiles complex expressions", () => {
+      const test = match
+        .hexCode("0afd")
+        .and.anyChar.thatRepeats.lazily.oneOrMore.groupedAs.namedCapture("test")
+        .and.capture(match.wordChar.as.namedCapture("test"), {
+          namespace: "prefix",
+          asPrefix: true
+        })
+        .and.backreferenceTo("prefixtest")
+        .compile([multiline, global])
+
+      expect(test).toEqual(/\u0afd(?<test>.+?)((?<prefixtest>\w))\k<prefixtest>/gm)
     })
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export * from "./Appenders"
 export * from "./Inputs"
 export * from "./Quantifiers"
 export * from "./Reggex"
+export * from "./BaseReggex"
 
 export const anyChar = Inputs.create().anyChar
 export const controlChar = Inputs.create().controlChar

--- a/src/transform.test.ts
+++ b/src/transform.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest"
+import { parse } from "acorn"
+import { ReggexTransformerPlugin } from "./transform"
+
+const testTransform = `
+  import { compileReggex, match } from "reggex"
+  const re1 = compileReggex(() => {
+    const test = "hello"
+    return match.anyChar.and.wordChar.as.namedCapture(test).and.anyChar
+  })
+`.trim()
+
+const testTransformNoImport = testTransform.split("\n").slice(1).join("\n")
+
+const expectedTransform = `
+  import { compileReggex, match } from "reggex"
+  const re1 = /.(?<hello>\\w)./
+`.trim()
+
+const expectedTransformNoImport = expectedTransform.split("\n").slice(1).join("\n")
+
+describe("transformer", () => {
+  it("ignores any non-JS files by default", () => {
+    expect(transform(testTransform, "test.css")).toBeUndefined()
+  })
+
+  it("ignores any files that don't import from reggex", () => {
+    const test1 = `import { match, compileReggex } from "reggx"\n//reggex\n` + testTransformNoImport
+    const test2 = `import { match, compileReggex } from "reggx"\n` + testTransformNoImport
+
+    expect(transform(test1)).toBeUndefined()
+    expect(transform(test2)).toBeUndefined()
+  })
+
+  it("ignores default exports", () => {
+    const expectedImports = `import reggex from "reggex"\n`
+    const test =
+      expectedImports +
+      testTransformNoImport
+        .replaceAll("match", "reggex.match")
+        .replaceAll("compileReggex", "reggex.compileReggex")
+
+    expect(transform(test)).toBeUndefined()
+  })
+
+  it("transforms js, jsx, ts, and tsx files", () => {
+    expect(transform(testTransform, "test.js")).toEqual(expectedTransform)
+    expect(transform(testTransform, "test.jsx")).toEqual(expectedTransform)
+    expect(transform(testTransform, "test.ts")).toEqual(expectedTransform)
+    expect(transform(testTransform, "test.tsx")).toEqual(expectedTransform)
+  })
+
+  it("handles namespaced imports", () => {
+    const expectedImports = `import * as reggex from "reggex"\n`
+    const test =
+      expectedImports +
+      testTransformNoImport
+        .replaceAll("match", "reggex.match")
+        .replaceAll("compileReggex", "reggex.compileReggex")
+
+    expect(transform(test)).toEqual(expectedImports + expectedTransformNoImport)
+  })
+
+  it("handles renamed imports", () => {
+    const expectedImports = `import { compileReggex as c, match as m } from "reggex"\n`
+    const test =
+      expectedImports +
+      testTransformNoImport.replaceAll("match", "m").replaceAll("compileReggex", "c")
+
+    expect(transform(test)).toEqual(expectedImports + expectedTransformNoImport)
+  })
+
+  it("handles more complex inputs", () => {
+    const test = `
+      import { something } from 'other-module'
+      import { match, global, multiline, namedCapture, group, compileReggex } from "reggex"
+      const re1 = group(namedCapture(test, match.anyChar.and.wordChar)).compile()
+
+      const a = 7 === 5 ? 5 : 7
+      console.log(a)
+      const hmm = (c) => { a + 1 + c }
+
+      const re2 = compileReggex(() => {
+        const test = "test"
+        const anyChar = match.anyChar
+        return match.anyChar.as
+          .namedCapture(test)
+          .and.append(anyChar)
+          .and.namedCapture(\`\${test}a\`, anyChar.as.namedCapture(test), {
+            namespace: "pre",
+            asPrefix: true
+          })
+          .and.group(anyChar.as.namedCapture(test), {
+            namespace: "suf",
+            asPrefix: false
+          })
+          .and.backreferenceTo("testsuf")
+      }, [global])
+
+      re2.test("abcab")
+
+      const test = "hello"
+      const re3 = compileReggex(() => {
+        const wordAndChar = group(namedCapture(test, match.anyChar.and.wordChar))
+        return match.anyChar.and.wordChar.as.namedCapture(test).and.anyChar.and.append(wordAndChar, { namespace: "pre", asPrefix: true })
+      }, [multiline])
+    `.trim()
+
+    const expected = `
+      import { something } from 'other-module'
+      import { match, global, multiline, namedCapture, group, compileReggex } from "reggex"
+      const re1 = group(namedCapture(test, match.anyChar.and.wordChar)).compile()
+
+      const a = 7 === 5 ? 5 : 7
+      console.log(a)
+      const hmm = (c) => { a + 1 + c }
+
+      const re2 = /(?<test>.).(?<testa>(?<pretest>.))(?:(?<testsuf>.))\\k<testsuf>/g
+
+      re2.test("abcab")
+
+      const test = "hello"
+      const re3 = compileReggex(() => {
+        const wordAndChar = group(namedCapture(test, match.anyChar.and.wordChar))
+        return match.anyChar.and.wordChar.as.namedCapture(test).and.anyChar.and.append(wordAndChar, { namespace: "pre", asPrefix: true })
+      }, [multiline])
+    `.trim()
+
+    expect(transform(test)).toEqual(expected)
+  })
+})
+
+/* eslint-disable */
+function transform(code: string | string[], id = "some-id.js", include?: RegExp[]) {
+  const plugin = ReggexTransformerPlugin.vite(
+    include === undefined ? undefined : { include }
+  ) as any
+
+  if ("transform" in plugin && typeof plugin.transform === "function") {
+    return plugin.transform.call(
+      { parse: (code: string) => parse(code, { ecmaVersion: 2022, sourceType: "module" }) },
+      Array.isArray(code) ? code.join("\n") : code,
+      id
+    )?.code
+  }
+}
+/* eslint-enable */

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,0 +1,113 @@
+import { Node, walk } from "estree-walker"
+import MagicString from "magic-string"
+import { findStaticImports, parseStaticImport } from "mlly"
+import { createUnplugin } from "unplugin"
+import { Context, Script } from "vm"
+import * as reggex from "./index"
+
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+
+/**
+ * Options for the ReggexTransformerPlugin
+ * @param include - An array of regexes that will be used to match any files that should be transformed
+ */
+export interface Options {
+  /**
+   * An array of regexes that will be used to match any files that should be transformed
+   */
+  include: RegExp[]
+}
+
+export const ReggexTransformerPlugin = createUnplugin(
+  (options: Options = { include: [/\.[tj]sx?$/g] }) => {
+    return {
+      name: "reggex-transformer-plugin",
+      enforce: "post",
+
+      transformInclude(id) {
+        // transform only files that match the include option
+        return options.include.some((r) => r.test(id))
+      },
+
+      transform(code, id) {
+        // only transform files that import from reggex
+        if (!code.includes("reggex")) return
+
+        const statements = findStaticImports(code).filter((i) => i.specifier === "reggex")
+
+        const context: Context = { ...reggex }
+        const namespaces: string[] = []
+        const wrappers: string[] = []
+
+        for (const statement of statements.flatMap((i) => parseStaticImport(i))) {
+          // add all exports from reggex to the context under a namespace
+          if (statement.namespacedImport) {
+            namespaces.push(statement.namespacedImport)
+            context[statement.namespacedImport] = reggex
+          }
+
+          // add all named exports from reggex to the context
+          if (statement.namedImports) {
+            for (const [name, alias] of Object.entries(statement.namedImports)) {
+              context[alias] = reggex[name as keyof typeof reggex]
+            }
+
+            // if the user imported compileReggex, add it to the wrappers
+            if (statement.namedImports.compileReggex) {
+              wrappers.push(statement.namedImports.compileReggex)
+            }
+          }
+
+          // default exports are ignored
+        }
+
+        const s = new MagicString(code)
+
+        walk(this.parse(code) as Node, {
+          enter(node) {
+            // only transform SimpleCallExpressions
+            if (node.type !== "CallExpression") return
+
+            // only transform calls to compileReggex or if it's a namespaced import
+            if (!wrappers.includes((node.callee as any)?.name)) {
+              if (
+                node.callee.type !== "MemberExpression" ||
+                node.callee.object.type !== "Identifier" ||
+                node.callee.property.type !== "Identifier" ||
+                node.callee.property.name !== "compileReggex" ||
+                !namespaces.includes((node.callee as any)?.object?.name)
+              )
+                return
+            }
+
+            // extract the start and end of the node
+            const { start, end } = node as unknown as { start: number; end: number }
+
+            try {
+              // evaluate the code and replace the call with the result
+              const script = new Script(code.slice(start, end))
+              const value = script.runInNewContext(context).toString()
+              s.overwrite(start, end, value)
+            } catch {
+              // silently ignore if the evaluation failed because Reggex can be evaluated at runtime
+            }
+          }
+        })
+
+        // only return the transformed code if it has changed
+        if (s.hasChanged()) {
+          return {
+            code: s.toString(),
+            map: s.generateMap({ includeContent: true, source: id })
+          }
+        }
+
+        return
+      }
+    }
+  }
+)

--- a/src/types/converters.ts
+++ b/src/types/converters.ts
@@ -4,16 +4,22 @@ import { Primitive } from "@types"
  * Join an array of primitives into a string
  * @param Primitives The array of primitives to join
  * @param Delimiter The delimiter to use between each primitive
+ * @param WrapStrings Whether or not to wrap strings in single quotes
  * @returns The joined string
  */
 type JoinPrimitives<
   Primitives extends Primitive[],
-  Delimiter extends string = " | "
+  Delimiter extends string = " | ",
+  WrapStrings extends boolean = true
 > = Primitives extends []
   ? ""
   : Primitives extends [infer Last]
   ? Last extends string
-    ? `'${Last}'`
+    ? WrapStrings extends true
+      ? `'${Last}'`
+      : Last extends Primitive
+      ? `${Last}`
+      : never
     : Last extends Primitive
     ? `${Last}`
     : never
@@ -21,9 +27,13 @@ type JoinPrimitives<
   ? Rest extends Primitive[]
     ? Primitives[0] extends infer Last
       ? Last extends string
-        ? `'${Last}'${Delimiter}${JoinPrimitives<Rest, Delimiter>}`
+        ? WrapStrings extends true
+          ? `'${Last}'${Delimiter}${JoinPrimitives<Rest, Delimiter, WrapStrings>}`
+          : Last extends Primitive
+          ? `${Last}${Delimiter}${JoinPrimitives<Rest, Delimiter, WrapStrings>}`
+          : never
         : Last extends Primitive
-        ? `${Last}${Delimiter}${JoinPrimitives<Rest, Delimiter>}`
+        ? `${Last}${Delimiter}${JoinPrimitives<Rest, Delimiter, WrapStrings>}`
         : never
       : never
     : never
@@ -33,18 +43,22 @@ type JoinPrimitives<
  * Join an array of primitives into a string
  * @param Tuple The tuple to join
  * @param Delimiter The delimiter to use between each primitive
+ * @param OnEmpty The string to return if the array is not an array of primitives or is empty
+ * @param WrapStrings Whether or not to wrap strings in single quotes
  * @returns The joined string or "N/A" if the array is not an array of primitives or is empty
  */
-export type Join<Tuple, Delimiter extends string = " | "> = Tuple extends [
-  infer First,
-  ...infer Rest
-]
+export type Join<
+  Tuple,
+  Delimiter extends string = " | ",
+  OnEmpty extends string = "N/A",
+  WrapStrings extends boolean = true
+> = Tuple extends [infer First, ...infer Rest]
   ? First extends Primitive
     ? Rest extends Primitive[]
-      ? JoinPrimitives<[First, ...Rest], Delimiter>
-      : "N/A"
-    : "N/A"
-  : "N/A"
+      ? JoinPrimitives<[First, ...Rest], Delimiter, WrapStrings>
+      : OnEmpty
+    : OnEmpty
+  : OnEmpty
 
 /**
  * Convert a tuple to an intersection

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -50,3 +50,9 @@ export type RegularMethod<T> = T extends (...args: unknown[]) => any ? ReturnTyp
  * A helper type to extract the return type of a getter method
  */
 export type GetMethod<T> = ReturnType<RegularMethod<T>>
+
+// prettier-ignore
+/**
+ * Flags for a regular expression
+ */
+export type Flag = "g" | "i" | "m" | "s" | "u" | "y" | "d"

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -155,3 +155,11 @@ export type NamespaceState<
     ">"
   >
 >
+
+declare const expressionSymbol: unique symbol
+/**
+ * A typed regular expression
+ */
+export type TypedRegExp<Expression extends string> = RegExp & {
+  [expressionSymbol]: Expression
+}

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -1,5 +1,6 @@
-import { assign, createState, merger } from "@utils"
+import { assign, compileReggex, createState, merger } from "@utils"
 import { describe, it, expect } from "vitest"
+import { global, match } from "../index"
 
 const method = Symbol("method")
 const property = Symbol("property")
@@ -160,6 +161,29 @@ describe("utils", () => {
           }
         })
       )
+    })
+  })
+
+  describe("compileReggex", () => {
+    it("compiles a regex and its flags", () => {
+      const test = compileReggex(() => {
+        const test = "test"
+        const anyChar = match.anyChar
+        return match.anyChar.as
+          .namedCapture(test)
+          .and.append(anyChar)
+          .and.namedCapture(`${test}a` as const, anyChar.as.namedCapture(test), {
+            namespace: "pre",
+            asPrefix: true
+          })
+          .and.group(anyChar.as.namedCapture(test), {
+            namespace: "suf",
+            asPrefix: false
+          })
+          .and.backreferenceTo("testsuf")
+      }, [global])
+
+      expect(test).toEqual(/(?<test>.).(?<testa>(?<pretest>.))(?:(?<testsuf>.))\k<testsuf>/g)
     })
   })
 })


### PR DESCRIPTION
- Add `compile` method to compile a Reggex into a TypedRegExp
- Add a `compileReggex` function to compile a Reggex into a TypedRegExp
- Add a transformer plugin that can be added to most build setups to resolve any calls to `compileReggex` that have no side-effects during compilation, leaving a plain RegExp in its place.